### PR TITLE
Validate coordinates on Bitmap#get and Bitmap#set

### DIFF
--- a/lib/bitmap_editor/bitmap.rb
+++ b/lib/bitmap_editor/bitmap.rb
@@ -4,17 +4,22 @@ module BitmapEditor
 
     attr_reader :width, :height
 
-    def initialize(width, height)
+    def initialize(width, height, validator = Validators::CoordinatesValidator)
       @width  = width
       @height = height
+      @validator = validator
       init(width, height)
     end
 
     def set(x, y, c)
+      validate_input!(x, y)
+
       bitmap[y][x] = c
     end
 
     def get(x, y)
+      validate_input!(x, y)
+
       bitmap[y][x]
     end
 
@@ -31,11 +36,17 @@ module BitmapEditor
     end
 
     private
-    attr_reader :bitmap
+    attr_reader :bitmap, :validator
 
     def init(width, height)
       @bitmap = Array.new(height) do
         Array.new(width) { DEFAULT_PIXEL_COLOR }
+      end
+    end
+
+    def validate_input!(x, y)
+      unless validator.new(self, x, y).valid?
+        raise Errors::OutOfBoundariesError.new(self, x, y)
       end
     end
   end

--- a/lib/bitmap_editor/errors/out_of_boundaries_error.rb
+++ b/lib/bitmap_editor/errors/out_of_boundaries_error.rb
@@ -1,0 +1,15 @@
+module BitmapEditor
+  module Errors
+    class OutOfBoundariesError < StandardError
+      def initialize(bitmap, x, y)
+        super(
+          %Q{
+            Coordinates X: #{x} and Y: #{y} are out of the bitmap boundaries,
+            coordinate X should be between 0 and #{bitmap.width}
+            coordinate Y should be between 0 and #{bitmap.height}
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/bitmap_editor/validators/coordinates_validator.rb
+++ b/lib/bitmap_editor/validators/coordinates_validator.rb
@@ -6,6 +6,7 @@ module BitmapEditor
         validate_coordinate(y, bitmap.height)
       end
 
+      private
       def validate_coordinate(position, dimension)
         position.between?(MIN_DIMENSION, dimension - 1)
       end

--- a/spec/bitmap_editor/bitmap_spec.rb
+++ b/spec/bitmap_editor/bitmap_spec.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
+require './lib/bitmap_editor/validators/base'
+require './lib/bitmap_editor/validators/coordinates_validator'
+require './lib/bitmap_editor/errors/out_of_boundaries_error'
 require './lib/bitmap_editor/bitmap'
 
 module BitmapEditor
@@ -6,16 +9,48 @@ module BitmapEditor
     let(:bitmap) { Bitmap.new(3, 4) }
 
     describe '#get' do
-      it 'should return the colour of a given coordinate' do
-        expect(bitmap.get(2, 2)).to eql 'O'
+      context 'when within bitmap boundaries' do
+        it 'returns the colour of a given coordinate' do
+          expect(bitmap.get(2, 2)).to eql 'O'
+        end
+      end
+
+      context 'when outside bitmap boundaries' do
+        it 'raises an OutOfBoundariesError error' do
+          expected_message = %Q{
+            Coordinates X: -1 and Y: -1 are out of the bitmap boundaries,
+            coordinate X should be between 0 and 3
+            coordinate Y should be between 0 and 4
+          }
+
+          expect {
+            bitmap.set(-1, -1, 'A')
+          }.to raise_error(Errors::OutOfBoundariesError, expected_message)
+        end
       end
     end
 
     describe '#set' do
-      it 'should set a coordinate with a given colour' do
-        bitmap.set(1, 1, 'A')
+      context 'when within bitmap boundaries' do
+        it 'sets a coordinate with a given colour' do
+          bitmap.set(1, 1, 'A')
 
-        expect(bitmap.get(1, 1)).to eql 'A'
+          expect(bitmap.get(1, 1)).to eql 'A'
+        end
+      end
+
+      context 'when outside bitmap boundaries' do
+        it 'raises an OutOfBoundariesError error' do
+          expected_message = %Q{
+            Coordinates X: -1 and Y: -1 are out of the bitmap boundaries,
+            coordinate X should be between 0 and 3
+            coordinate Y should be between 0 and 4
+          }
+
+          expect {
+            bitmap.set(-1, -1, 'A')
+          }.to raise_error(Errors::OutOfBoundariesError, expected_message)
+        end
       end
     end
 


### PR DESCRIPTION
This commit adds OutOfBoundariesError so it can be raised when the input coordinates are
not within the Bitmap boundaries.