### PR TITLE
Bitmap base functionality

### DIFF
--- a/lib/bitmap_editor/bitmap.rb
+++ b/lib/bitmap_editor/bitmap.rb
@@ -13,11 +13,11 @@ module BitmapEditor
     end
 
     def set(x, y, c)
-      bitmap[x][y] = c
+      bitmap[y][x] = c
     end
 
     def get(x, y)
-      bitmap[x][y]
+      bitmap[y][x]
     end
 
     def clear!

--- a/lib/bitmap_editor/bitmap.rb
+++ b/lib/bitmap_editor/bitmap.rb
@@ -2,7 +2,7 @@ module BitmapEditor
   class Bitmap
     MIN_DIMENSION       = 0
     MAX_DIMENSION       = 250
-    DEFAULT_PIXEL_COLOR = 'O'
+    DEFAULT_PIXEL_COLOR = 'O'.freeze
 
     attr_reader :bitmap, :width, :height
 
@@ -12,7 +12,15 @@ module BitmapEditor
       init(width, height)
     end
 
-    def clear
+    def set(x, y, c)
+      bitmap[x][y] = c
+    end
+
+    def get(x, y)
+      bitmap[x][y]
+    end
+
+    def clear!
       init(width, height)
     end
 

--- a/lib/bitmap_editor/commands/fill_region.rb
+++ b/lib/bitmap_editor/commands/fill_region.rb
@@ -1,29 +1,31 @@
 module BitmapEditor
-  class FillRegion
-    attr_reader :bitmap, :x, :y, :c
+  module Commands
+    class FillRegion
+      attr_reader :bitmap, :x, :y, :c
 
-    def initialize(bitmap, x, y, c)
-      @bitmap = bitmap
-      @x, @y, @c = x, y, c
-    end
+      def initialize(bitmap, x, y, c)
+        @bitmap = bitmap
+        @x, @y, @c = x, y, c
+      end
 
-    def perform
-      _fill(x, y, c)
-    end
+      def perform
+        _fill(x, y, c)
+      end
 
-    private
+      private
 
-    def _fill(x, y, c)
-      return if (x < MIN_DIMENSION || x == @width)
-      return if (y < MIN_DIMENSION || y == @height)
-      return if (pixels[y][x] == c) || (pixels[y][x] != 'O')
+      def _fill(x, y, c)
+        return if (x < MIN_DIMENSION || x == @width)
+        return if (y < MIN_DIMENSION || y == @height)
+        return if (pixels[y][x] == c) || (pixels[y][x] != 'O')
 
-      pixels[y][x] = c
+        pixels[y][x] = c
 
-      flood_fill(x - 1, y, c)
-      flood_fill(x + 1, y, c)
-      flood_fill(x, y + 1, c)
-      flood_fill(x, y - 1, c)
+        flood_fill(x - 1, y, c)
+        flood_fill(x + 1, y, c)
+        flood_fill(x, y + 1, c)
+        flood_fill(x, y - 1, c)
+      end
     end
   end
 end

--- a/spec/bitmap_editor/bitmap_spec.rb
+++ b/spec/bitmap_editor/bitmap_spec.rb
@@ -5,9 +5,28 @@ module BitmapEditor
   RSpec.describe Bitmap do
     let(:bitmap) { Bitmap.new(3, 4) }
 
-    describe '#clear' do
+    describe '#get' do
+      it 'should return the colour of a given coordinate' do
+        expect(bitmap.get(2, 2)).to eql 'O'
+      end
+    end
+
+    describe '#set' do
+      it 'should set a coordinate with a given colour' do
+        bitmap.set(1, 1, 'A')
+
+        expect(bitmap.get(1, 1)).to eql 'A'
+      end
+    end
+
+    describe '#clear!' do
       it 'resets the bitmap to have default colour' do
-        expect(bitmap.bitmap).to eql(bitmap.clear)
+        bitmap.set(1, 2, 'B')
+
+        expect(bitmap.get(1, 2)).to eql 'B'
+        bitmap.clear!
+
+        expect(bitmap.get(1, 2)).to eql 'O'
       end
     end
   end

--- a/spec/bitmap_editor/bitmap_spec.rb
+++ b/spec/bitmap_editor/bitmap_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require './lib/bitmap_editor/bitmap.rb'
+require './lib/bitmap_editor/bitmap'
 
 module BitmapEditor
   RSpec.describe Bitmap do


### PR DESCRIPTION
Redesign public API for BitmapEditor::Bitmap

The Bitmap class now has 3 public instance methods:

- #get - returns value of a given coordinate
- #set - sets a value in a given coordinate
- #clear! - clears the whole bitmap

The creation of both #get/#set methods allows me to have access to the bitmap coordinates individually.

Doing it this way also permits the API to remain the same in the future even if the data structure changes.

This commit also properly namespaces `FillRegion` under `BitmapEditor::Commands`