### PR TITLE
Add validation to coordinates

### DIFF
--- a/lib/bitmap_editor/bitmap.rb
+++ b/lib/bitmap_editor/bitmap.rb
@@ -22,6 +22,19 @@ module BitmapEditor
       init(width, height)
     end
 
+    def width
+      bitmap[0].size
+    end
+
+    def height
+      bitmap.size
+    end
+
+    def valid_coordinates?(x, y)
+      validate_coordinate(x, width) &&
+      validate_coordinate(y, height)
+    end
+
     private
     attr_reader :bitmap, :width, :height
 
@@ -29,6 +42,10 @@ module BitmapEditor
       @bitmap = Array.new(height) do
         Array.new(width) { DEFAULT_PIXEL_COLOR }
       end
+    end
+
+    def validate_coordinate(position, dimension)
+      position.between?(MIN_DIMENSION, dimension - 1)
     end
   end
 end

--- a/spec/bitmap_editor/bitmap_spec.rb
+++ b/spec/bitmap_editor/bitmap_spec.rb
@@ -29,5 +29,60 @@ module BitmapEditor
         expect(bitmap.get(1, 2)).to eql 'O'
       end
     end
+
+    describe '#valid_coordinates?' do
+      context 'when coordinate is out of bounds' do
+        it 'returns false for coordinate next to left side' do
+          expect(
+            bitmap.valid_coordinates?(-1, 0)
+          ).to be false
+        end
+
+        it 'returns false for coordiate over the top' do
+          expect(
+            bitmap.valid_coordinates?(0, -1)
+          ).to be false
+        end
+
+        it 'returns false for coordinate next to right side' do
+          expect(
+            bitmap.valid_coordinates?(3, 1)
+          ).to be false
+        end
+
+        it 'returns false for coordinate under the bottom' do
+          expect(
+            bitmap.valid_coordinates?(1, 4)
+          ).to be false
+        end
+      end
+
+      context 'when coordinate is within bounds' do
+        it 'returns true for top-left' do
+          expect(
+            bitmap.valid_coordinates?(0, 0)
+          ).to be true
+        end
+
+        it 'returns true for top-right' do
+          expect(
+
+            bitmap.valid_coordinates?(2, 0)
+          ).to be true
+        end
+
+        it 'returns true for bottom-right' do
+          expect(
+            bitmap.valid_coordinates?(2, 3)
+          ).to be true
+        end
+
+        it 'returns true for bottom-left' do
+          expect(
+            bitmap.valid_coordinates?(0, 3)
+          ).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds validation to the coordinates passed to the bitmap.

This only tests the bitmap boundaries and makes sure the given coordinates are able to be set within the Bitmap.